### PR TITLE
Fix location of librga

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,8 +64,8 @@ RUN git clone https://github.com/mesonbuild/meson.git && \
 
 # Install librga
 WORKDIR /root
-RUN git clone https://github.com/rockchip-linux/linux-rga.git && \
-    cd linux-rga && \
+RUN git clone https://github.com/amarula/rockchip-linux-rga.git && \
+    cd rockchip-linux-rga && \
     meson builddir && \
     cd builddir && \
     meson compile && \


### PR DESCRIPTION
When I tried to build the docker image, I got an error on the librga pull from github. I believe I found a replacement URL that works.