### PR TITLE
Update Dockerfile to download proper linux-rga

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,8 +64,9 @@ RUN git clone https://github.com/mesonbuild/meson.git && \
 
 # Install librga
 WORKDIR /root
-RUN git clone https://github.com/rockchip-linux/linux-rga.git && \
+RUN git clone https://github.com/christianhaitian/linux-rga.git && \
     cd linux-rga && \
+    git checkout 1fc02d56d97041c86f01bc1284b7971c6098c5fb && \
     meson builddir && \
     cd builddir && \
     meson compile && \


### PR DESCRIPTION
Update dockerfile to reflect proper linux-rga repo from christianhaitian as https://github.com/rockchip-linux/linux-rga.git ain't available anymore due to rockchip removing some of their open sources projects from github